### PR TITLE
Include source build and deployment to PyPI

### DIFF
--- a/.github/workflows/all-build.yml
+++ b/.github/workflows/all-build.yml
@@ -39,8 +39,12 @@ jobs:
           name: my-artifact-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
-
-
+      - name: Build source distribution
+        run: python setup.py sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: source-dist-${{ matrix.os }}
+          path: ./dist/*.tar.gz
 
   upload_all:
     needs: [build_wheels]
@@ -53,6 +57,11 @@ jobs:
        with:
         path: dist
         pattern: my-artifact-*
+        merge-multiple: true
+     - uses: actions/download-artifact@v4
+       with:
+        path: dist
+        pattern: source-dist-*
         merge-multiple: true
      - name: List directory contents
        run: |

--- a/.github/workflows/all-build.yml
+++ b/.github/workflows/all-build.yml
@@ -1,6 +1,6 @@
 name: Build Test and Publish
 
-on: [push, pull_request,release,workflow_dispatch]
+on: [push, pull_request, release, workflow_dispatch]
 
 jobs:
   build_wheels:
@@ -21,33 +21,36 @@ jobs:
         
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
-        # to supply options, put them in 'env', like:
         env:
-            #   CIBW_SOME_OPTION: value
             # remove python <3.9 and musllinux
             CIBW_SKIP: "cp27-* cp35-* cp36-* cp37-* cp38-* pp* *-win32 *win_arm64 *i686 *-musllinux* cp312-manylinux_x86_64"
-            # CIBW_BEFORE_ALL_WINDOWS: >
-            # vcpkg update &&
-            # vcpkg install getopt:x64-windows-static &&
-            # vcpkg integrate install
-            # test tests/test_agent.py
-            # CIBW_TEST_REQUIRES: pytest tqdm
-            # CIBW_TEST_COMMAND: "pytest {project}/tests"
             CIBW_TEST_COMMAND: "python {project}/docs/tutorial/example.py"
+            
       - uses: actions/upload-artifact@v4
         with:
           name: my-artifact-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest  # Build the source distribution once on any OS (Ubuntu is fine)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tool
+        run: python -m pip install build
+
       - name: Build source distribution
-        run: python setup.py sdist
+        run: python -m build --sdist --outdir dist
+
       - uses: actions/upload-artifact@v4
         with:
-          name: source-dist-${{ matrix.os }}
+          name: source-dist
           path: ./dist/*.tar.gz
 
   upload_all:
-    needs: [build_wheels]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/cxrandomwalk/Python/PyCXVersion.h
+++ b/cxrandomwalk/Python/PyCXVersion.h
@@ -1,1 +1,1 @@
-#define k_PYCXVersion 0.5.7
+#define k_PYCXVersion 0.5.8

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,8 @@ setup(
             # library_dirs=extraLibraryPaths,
             # libraries = ["getopt"] if building_on_windows else [],
         ),
-    ]
+    ],
+    cmdclass={
+        'sdist': setuptools.command.sdist.sdist,
+    }
 )
-
-        

--- a/setup.py
+++ b/setup.py
@@ -143,8 +143,5 @@ setup(
             # library_dirs=extraLibraryPaths,
             # libraries = ["getopt"] if building_on_windows else [],
         ),
-    ],
-    cmdclass={
-        'sdist': setuptools.command.sdist.sdist,
-    }
+    ]
 )


### PR DESCRIPTION
Add source distribution build and deployment to GitHub action

* Modify `setup.py` to include a step for building the source distribution using `python setup.py sdist`.
* Modify `.github/workflows/all-build.yml` to add steps for building the source distribution and uploading it as an artifact.
* Increase the minor version in `cxrandomwalk/Python/PyCXVersion.h` from 0.5.7 to 0.5.8.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/filipinascimento/cxrandomwalk?shareId=2f9a921d-9589-47cd-992e-1aaade105fc8).